### PR TITLE
Add GitHub Actions workflow for Copilot setup

### DIFF
--- a/copilot-setup-steps.yml
+++ b/copilot-setup-steps.yml
@@ -1,0 +1,33 @@
+name: "Copilot Setup Steps"
+
+on: workflow_dispatch
+jobs:
+  # This is the required job name. If different, Copilot will ignore it.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+ 
+  # Starts a MongoDB service for Copilot to use during its session.
+    services:
+     mongo:
+       image: mongo:7
+       ports:
+         - 27017:27017
+
+    # Grant Copilot early access to read the repository content.
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r src/requirements.txt


### PR DESCRIPTION

This pull request introduces a new GitHub Actions workflow file named `copilot-setup-steps.yml` to automate the setup process for Copilot sessions. The workflow provisions a MongoDB service, checks out the repository code, sets up Python 3.13, and installs required Python dependencies.

Workflow automation and environment setup:

* Added a new workflow file `copilot-setup-steps.yml` that defines a `copilot-setup-steps` job triggered by `workflow_dispatch`, which sets up the environment for Copilot, including provisioning a MongoDB service (`mongo:7`) and granting read permissions to repository contents.
* Configured steps to check out the code (`actions/checkout@v5`), set up Python 3.13 (`actions/setup-python@v6`), and install dependencies from `src/requirements.txt` using pip.